### PR TITLE
Fixed notification in connection with the new header

### DIFF
--- a/Notification.qml
+++ b/Notification.qml
@@ -7,7 +7,7 @@ Rectangle {
     anchors {
         horizontalCenter: parent.horizontalCenter
         bottom: parent.bottom
-        margins: (toolbar.opened && !toolbar.locked ? toolbar.height : 0) + units.gu(2) + ((!mainView.anchorToKeyboard && Qt.inputMethod.visible) ? Qt.inputMethod.keyboardRectangle.height : 0)
+        margins: (mainView.useDeprecatedToolbar && toolbar.opened && !toolbar.locked ? toolbar.height : 0) + units.gu(2) + ((!mainView.anchorToKeyboard && Qt.inputMethod.visible) ? Qt.inputMethod.keyboardRectangle.height : 0)
     }
 
     height: label.height + units.gu(3)
@@ -79,3 +79,4 @@ Rectangle {
         return up
     }
 }
+


### PR DESCRIPTION
Previously, the notification was shown at the bottom of the page without any margin. This commit fixes the issue.
